### PR TITLE
Specify required node version

### DIFF
--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id "com.github.node-gradle.node"
 }
 
+node {
+    download = true
+    version = "14.8.0"
+}
+
 npm_ci {
     inputs.file "package.json"
     outputs.dir "node_modules"

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id "com.github.node-gradle.node"
 }
 
+node {
+    download = true
+    version = "14.8.0"
+}
+
 npm_ci {
     inputs.file "package.json"
     outputs.dir "node_modules"


### PR DESCRIPTION
Use local rather than system node version in Gradle builds to avoid
version incompatibilities.