### PR TITLE
Use skaffold to deploy the animal-rescue app and SCG object to k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,32 @@ All the gateway configuration can be found and updated here:
 - Frontend routes configuration used on binding used on bind: `./frontend/gateway-config.json`
 - Backend routes configuration used on binding used on bind:`./backend/gateway-config.json` 
 
+## Deploy to Kubernetes
+
+Make sure you have Spring Cloud Gateway for k8s installed.
+
+If you have `kustomize` installed, you can run the following command:
+
+```bash
+kustomize build ./k8s | kubectl apply -f -
+```
+
+If you don't want to use `kustomize`, you can apply each yaml file in the `k8s` folder manually into the `animal-rescue` namespace (or any namespace you like!).
+
+There are two gateway instance being created - `animal-rescue-gateway` and `animal-rescue-gateway-with-dynamic-routes`. 
+* `animal-rescue-gateway` has all the routes pre-defined when creating the gateway. 
+* `animal-rescue-gateway-with-dynamic-routes` doesn't have any routes defined on creation. The route definition is defined in a `SpringCloudGatewayBinding` object that can be version-controlled with each routed application.
+
+After applying all the manifest files, there should be a SCG deployment and a `ClusterIP` service for each gateway instance deployed in the SCG installation namespace (`spring-cloud-gateway` by default).
+
+Expose your gateway instance in your favorite way, e.g. ingress or port forwarding, then access `/rescue` path` to view the animal-rescue app.
+
 ## Special frontend config related to gateway
 
 The frontend application is implemented in ReactJS, and is pushed with static buildpack. Because of it's static nature, we had to do the following 
 1. `homepage` in `package.json` is set to `/rescue`, which is the path we set for the frontend application in gateway config (`frontend/gateway-config.json`). This is to make sure all related assets is requested under `/rescue` path as well.
 1. `Sign in to adopt` button is linked to `/rescue/login`, which is a path that is `sso-enabled` in gateway config (`frontend/gateway-config.json`). This is necessary for frontend apps bound to a sub path on gateway because the Oauth2 login flow redirects users to the original requested location or back to `/` if no saved request exists. This setting is not necessary if the frontend app is bound to path `/`.
 1. `REACT_APP_BACKEND_BASE_URI` is set to `/backend` in build script, which is the path we set for the backend application in gateway config (`backend/gateway-config.json`). This is to make sure all our backend API calls are appended with the `backend` path.
-
 
 ## Try it out
 Visit `https://gateway-demo.${appsDomain}/rescue`, you should see cute animal bios with the `Adopt` buttons disabled. All the information are fetched from a public `GET` backend endpoint `/animals`. 

--- a/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/AnimalController.java
+++ b/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/AnimalController.java
@@ -32,6 +32,9 @@ public class AnimalController {
 
 	@GetMapping("/whoami")
 	public String whoami(Principal principal) {
+		if (principal == null) {
+			return "";
+		}
 		return principal.getName();
 	}
 

--- a/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/KubernetesSecurityConfiguration.java
+++ b/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/KubernetesSecurityConfiguration.java
@@ -1,0 +1,23 @@
+package io.spring.cloud.samples.animalrescue.backend;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@Profile("k8s")
+public class KubernetesSecurityConfiguration {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesSecurityConfiguration.class);
+
+	@Bean
+	public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity httpSecurity) {
+		return httpSecurity.httpBasic().disable().build();
+	}
+
+}

--- a/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/SecurityConfiguration.java
+++ b/backend/src/main/java/io/spring/cloud/samples/animalrescue/backend/SecurityConfiguration.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
@@ -15,10 +14,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler;
 import org.springframework.security.web.server.authentication.logout.RedirectServerLogoutSuccessHandler;
-import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 
 @Configuration
-@Profile("!cloud") // cloud profile is automatically activated on CloudFoundry
+@Profile("!cloud & !k8s") // cloud profile is automatically activated on CloudFoundry
 public class SecurityConfiguration {
 
 	@Bean

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.17
+COPY build /usr/share/nginx/html

--- a/k8s/animal-rescue-backend.yaml
+++ b/k8s/animal-rescue-backend.yaml
@@ -35,3 +35,17 @@ spec:
       targetPort: 8080
   selector:
     app: animal-rescue-backend
+
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayBinding
+metadata:
+  name: animal-rescue-backend-routes
+spec:
+  gateway: animal-rescue-gateway-with-dynamic-routes
+  service: animal-rescue-backend
+  routes:
+    - predicates:
+        - Path=/api/**
+      filters:
+        - StripPrefix=1

--- a/k8s/animal-rescue-backend.yaml
+++ b/k8s/animal-rescue-backend.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: animal-rescue-backend
+spec:
+  selector:
+    matchLabels:
+      app: animal-rescue-backend
+  template:
+    metadata:
+      labels:
+        app: animal-rescue-backend
+    spec:
+      containers:
+        - name: animal-rescue-backend
+          image: springcloudservices/animal-rescue-backend
+          env:
+            - name: spring.profiles.active
+              value: k8s
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: animal-rescue-backend
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: animal-rescue-backend

--- a/k8s/animal-rescue-frontend.yaml
+++ b/k8s/animal-rescue-frontend.yaml
@@ -28,3 +28,17 @@ spec:
       targetPort: 80
   selector:
     app: animal-rescue-frontend
+
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayBinding
+metadata:
+  name: animal-rescue-frontend-routes
+spec:
+  gateway: animal-rescue-gateway-with-dynamic-routes
+  service: animal-rescue-frontend
+  routes:
+    - predicates:
+        - Path=/rescue/**
+      filters:
+        - StripPrefix=1

--- a/k8s/animal-rescue-frontend.yaml
+++ b/k8s/animal-rescue-frontend.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: animal-rescue-frontend
+spec:
+  selector:
+    matchLabels:
+      app: animal-rescue-frontend
+  template:
+    metadata:
+      labels:
+        app: animal-rescue-frontend
+    spec:
+      containers:
+        - name: animal-rescue-frontend
+          image: springcloudservices/animal-rescue-frontend
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: animal-rescue-frontend
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    app: animal-rescue-frontend

--- a/k8s/animal-rescue-frontend.yaml
+++ b/k8s/animal-rescue-frontend.yaml
@@ -14,7 +14,6 @@ spec:
       containers:
         - name: animal-rescue-frontend
           image: springcloudservices/animal-rescue-frontend
-          imagePullPolicy: Always
           ports:
             - containerPort: 80
       restartPolicy: Always

--- a/k8s/animal-rescue-gateway-with-dynamic-routes.yaml
+++ b/k8s/animal-rescue-gateway-with-dynamic-routes.yaml
@@ -1,0 +1,5 @@
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGateway
+metadata:
+  name: animal-rescue-gateway-with-dynamic-routes
+spec: {}

--- a/k8s/animal-rescue-gateway.yaml
+++ b/k8s/animal-rescue-gateway.yaml
@@ -1,0 +1,20 @@
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGateway
+metadata:
+  name: animal-rescue-gateway
+spec:
+  routes:
+    - id: animal-rescue-frontend
+      uri: http://animal-rescue-frontend.spring-cloud-gateway.svc.cluster.local
+      predicates:
+        - Path=/rescue/**
+      filters:
+        - StripPrefix=1
+    - id: animal-rescue-backend
+      uri: http://animal-rescue-backend.spring-cloud-gateway.svc.cluster.local
+      predicates:
+        - Path=/api/**
+      filters:
+        - StripPrefix=1
+  count: 2
+  tlsCertSecretName: wildcard-cert-tls

--- a/k8s/animal-rescue-gateway.yaml
+++ b/k8s/animal-rescue-gateway.yaml
@@ -5,16 +5,14 @@ metadata:
 spec:
   routes:
     - id: animal-rescue-frontend
-      uri: http://animal-rescue-frontend.spring-cloud-gateway.svc.cluster.local
+      uri: http://animal-rescue-frontend.animal-rescue.svc.cluster.local
       predicates:
         - Path=/rescue/**
       filters:
         - StripPrefix=1
     - id: animal-rescue-backend
-      uri: http://animal-rescue-backend.spring-cloud-gateway.svc.cluster.local
+      uri: http://animal-rescue-backend.animal-rescue.svc.cluster.local
       predicates:
         - Path=/api/**
       filters:
         - StripPrefix=1
-  count: 2
-  tlsCertSecretName: wildcard-cert-tls

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: spring-cloud-gateway
+
+resources:
+#  - namespace.yaml
+  - animal-rescue-frontend.yaml
+  - animal-rescue-backend.yaml
+  - animal-rescue-gateway.yaml
+

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: spring-cloud-gateway
+namespace: animal-rescue
 
 resources:
-#  - namespace.yaml
+  - namespace.yaml
   - animal-rescue-frontend.yaml
   - animal-rescue-backend.yaml
   - animal-rescue-gateway.yaml
-
+  - animal-rescue-gateway-with-dynamic-routes.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: animal-rescue

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,8 +10,9 @@ build:
       builder: gcr.io/paketo-buildpacks/builder:base-platform-api-latest
       dependencies:
         paths:
-        - src
+        - src/main/**
         - build.gradle
+        - settings.gradle
   - image: springcloudservices/animal-rescue-frontend
     context: frontend
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,21 @@
+apiVersion: skaffold/v2beta6
+kind: Config
+build:
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: springcloudservices/animal-rescue-backend
+    context: backend
+    buildpacks:
+      builder: gcr.io/paketo-buildpacks/builder:base-platform-api-latest
+      dependencies:
+        paths:
+        - src
+        - build.gradle
+  - image: springcloudservices/animal-rescue-frontend
+    context: frontend
+
+deploy:
+  kustomize:
+    paths:
+      - k8s


### PR DESCRIPTION
Hardcoding uri for the animal-rescue apps. We should use the `SpringCloudGatewayBinding` object after we merge [this PR](https://github.com/pivotal-cf/spring-cloud-gateway-k8s/pull/17).
