### PR TITLE
Upgrade gradle version in the backend folder

### DIFF
--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[This PR](https://github.com/spring-cloud-services-samples/animal-rescue/pull/89) upgraded gradle in the root directory but not in the backend folder. The test steps uses the root gradle wrapper for all tests, but the publish job is only set in the context of the backend folder to generate the image, so [CI failed on publish](https://github.com/spring-cloud-services-samples/animal-rescue/actions/runs/1303818623). This commit should fix that.