### PR TITLE
Fix Skaffold error by changing backend's builder to base-platform-api-latest

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,7 @@ build:
   - image: springcloudservices/animal-rescue-backend
     context: backend
     buildpacks:
-      builder: gcr.io/paketo-buildpacks/builder:base
+      builder: gcr.io/paketo-buildpacks/builder:base-platform-api-latest
       dependencies:
         paths:
         - src/main/**


### PR DESCRIPTION
```
Waiting for deployments to stabilize...
 - animal-rescue:deployment/animal-rescue-frontend is ready. [1/2 deployment(s) still pending]
 - animal-rescue:deployment/animal-rescue-backend: container animal-rescue-backend terminated with exit code 82
    - animal-rescue:pod/animal-rescue-backend-56585887b4-zrm4h: container animal-rescue-backend terminated with exit code 82
      > [animal-rescue-backend-56585887b4-zrm4h animal-rescue-backend] ERROR: failed to launch: determine start command: when there is no default process a command is required
 - animal-rescue:deployment/animal-rescue-backend failed. Error: container animal-rescue-backend terminated with exit code 82.
```
[Slack thread](https://vmware.slack.com/archives/G01QUTLK6NQ/p1644859440467929).