### PR TITLE
Add configuration to run on Tanzu Application Platform

### DIFF
--- a/backend/Tiltfile
+++ b/backend/Tiltfile
@@ -1,0 +1,23 @@
+LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
+NAMESPACE = os.getenv("NAMESPACE", default='default')
+WAIT_TIMEOUT = os.getenv("WAIT_TIMEOUT", default='10m00s')
+TYPE = os.getenv("TYPE", default='web')
+
+k8s_custom_deploy(
+    'animal-rescue-backend',
+    apply_cmd="tanzu apps workload apply -f config/workload.yaml --update-strategy replace --debug --live-update" +
+        " --local-path " + LOCAL_PATH +
+        " --namespace " + NAMESPACE +
+        " --wait-timeout " + WAIT_TIMEOUT +
+        " --type " + TYPE +
+        " --yes --output yaml",
+    delete_cmd="tanzu apps workload delete -f config/workload.yaml --namespace " + NAMESPACE + " --yes" ,
+    deps=['pom.xml', './target/classes'],
+    container_selector='workload',
+    live_update=[
+        sync('./target/classes', '/workspace/BOOT-INF/classes')
+    ]
+)
+
+k8s_resource('animal-rescue-backend', port_forwards=["8080:8080"],
+    extra_pod_selectors=[{'carto.run/workload-name': 'animal-rescue-backend', 'app.kubernetes.io/component': 'run'}])

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	implementation "org.springframework.cloud:spring-cloud-bindings:2.0.2"
+
 	implementation "org.springframework.security:spring-security-web"
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/config/workload.yml
+++ b/backend/config/workload.yml
@@ -15,8 +15,6 @@ spec:
   env:
     - name: MANAGEMENT_ENDPOINT_HEALTH_GROUP_LIVE_ADDITIONAL_PATH
       value: server:/startupz
-    - name: BP_SPRING_CLOUD_BINDINGS_VERSION
-      value: 1.13.0
     - name: spring_profiles_active
       value: k8s,tap
   serviceClaims:

--- a/backend/config/workload.yml
+++ b/backend/config/workload.yml
@@ -1,48 +1,7 @@
-#@ load("@ytt:data", "data")
-
----
-apiVersion: carto.run/v1alpha1
-kind: Workload
-metadata:
-  name: animal-rescue-frontend
-  namespace: #@ data.values.workloadNamespace
-  labels:
-    apps.tanzu.vmware.com/workload-type: server
-    app.kubernetes.io/part-of: animal-rescue-frontend
-    apps.tanzu.vmware.com/has-tests: "true"
-    apps.tanzu.vmware.com/auto-configure-actuators: "true"    
-spec:
-  build:
-    env:
-    - name: BP_EXCLUDE_FILES
-      value: 'build.gradle'
-    - name: BP_NODE_RUN_SCRIPTS
-      value: build
-    - name: BP_WEB_SERVER_ROOT
-      value: dist      
-  params:
-  - name: ports
-    value:
-    - port: 80
-      containerPort: 8080
-      name: http
-  resources:
-    requests:
-      memory: 500M
-    limits:
-      memory: 750M    
-  source:
-    subPath: frontend
-    git:
-      url: https://github.com/spring-cloud-services-samples/animal-rescue
-      ref:
-        branch: main
----
 apiVersion: carto.run/v1alpha1
 kind: Workload
 metadata:
   name: animal-rescue-backend
-  namespace: #@ data.values.workloadNamespace
   labels:
     apps.tanzu.vmware.com/workload-type: server
     app.kubernetes.io/part-of: animal-rescue-backend

--- a/backend/config/workload.yml
+++ b/backend/config/workload.yml
@@ -26,6 +26,9 @@ spec:
         kind: ClassClaim
         name: appsso-animal-rescue
   params:
+  - name: testing_pipeline_matching_labels
+    value:
+        apps.tanzu.vmware.com/pipeline: rescue-generic-test 
   - name: ports
     value:
     - port: 80

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,4 @@
+---
 management:
   endpoint:
     health:
@@ -23,3 +24,7 @@ springdoc:
     path: /api-docs
   show-actuator: true
 
+---
+spring:
+  config.activate.on-profile: tap
+  security.oauth2.resourceserver.jwt.jwk-set-uri: '${spring.security.oauth2.client.provider.appsso.issuer-uri}/oauth2/jwks'

--- a/frontend/config/workload.yml
+++ b/frontend/config/workload.yml
@@ -1,0 +1,37 @@
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: animal-rescue-frontend
+  namespace: workloads
+  labels:
+    apps.tanzu.vmware.com/workload-type: server
+    app.kubernetes.io/part-of: animal-rescue-frontend
+    apps.tanzu.vmware.com/has-tests: "true"
+    networking.knative.dev/visibility: cluster-local
+    apps.tanzu.vmware.com/auto-configure-actuators: "true"    
+spec:
+  build:
+    env:
+    - name: BP_EXCLUDE_FILES
+      value: 'build.gradle'
+    - name: BP_NODE_RUN_SCRIPTS
+      value: build
+    - name: BP_WEB_SERVER_ROOT
+      value: dist      
+  params:
+  - name: ports
+    value:
+    - port: 80
+      containerPort: 8080
+      name: http
+  resources:
+    requests:
+      memory: 500M
+    limits:
+      memory: 750M    
+  source:
+    subPath: frontend
+    git:
+      url: https://github.com/spring-cloud-services-samples/animal-rescue
+      ref:
+        branch: main

--- a/frontend/config/workload.yml
+++ b/frontend/config/workload.yml
@@ -19,6 +19,9 @@ spec:
     - name: BP_WEB_SERVER_ROOT
       value: dist      
   params:
+  - name: testing_pipeline_matching_labels
+    value:
+        apps.tanzu.vmware.com/pipeline: rescue-generic-test 
   - name: ports
     value:
     - port: 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,175 @@
+# Number of worker processes running in container
+worker_processes 1;
+
+# Run NGINX in foreground (necessary for containerized NGINX)
+daemon off;
+
+# Do not set the location of the server's PID file as it is already provided by the WebServers Buildpack
+# pid /tmp/nginx.pid;
+
+# Set the location of the server's error log
+error_log stderr;
+
+events {
+  # Set number of simultaneous connections each worker process can serve
+  worker_connections 1024;
+}
+
+http {
+  client_body_temp_path /tmp/client_body_temp;
+  proxy_temp_path /tmp/proxy_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+
+  charset utf-8;
+
+  # Map media types to file extensions
+  types {
+    text/html html htm shtml;
+    text/css css;
+    text/xml xml;
+    image/gif gif;
+    image/jpeg jpeg jpg;
+    application/javascript js;
+    application/atom+xml atom;
+    application/rss+xml rss;
+    font/ttf ttf;
+    font/woff woff;
+    font/woff2 woff2;
+    text/mathml mml;
+    text/plain txt;
+    text/vnd.sun.j2me.app-descriptor jad;
+    text/vnd.wap.wml wml;
+    text/x-component htc;
+    text/cache-manifest manifest;
+    image/png png;
+    image/tiff tif tiff;
+    image/vnd.wap.wbmp wbmp;
+    image/x-icon ico;
+    image/x-jng jng;
+    image/x-ms-bmp bmp;
+    image/svg+xml svg svgz;
+    image/webp webp;
+    application/java-archive jar war ear;
+    application/mac-binhex40 hqx;
+    application/msword doc;
+    application/pdf pdf;
+    application/postscript ps eps ai;
+    application/rtf rtf;
+    application/vnd.ms-excel xls;
+    application/vnd.ms-powerpoint ppt;
+    application/vnd.wap.wmlc wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz kmz;
+    application/x-7z-compressed 7z;
+    application/x-cocoa cco;
+    application/x-java-archive-diff jardiff;
+    application/x-java-jnlp-file jnlp;
+    application/x-makeself run;
+    application/x-perl pl pm;
+    application/x-pilot prc pdb;
+    application/x-rar-compressed rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea sea;
+    application/x-shockwave-flash swf;
+    application/x-stuffit sit;
+    application/x-tcl tcl tk;
+    application/x-x509-ca-cert der pem crt;
+    application/x-xpinstall xpi;
+    application/xhtml+xml xhtml;
+    application/zip zip;
+    application/octet-stream bin exe dll;
+    application/octet-stream deb;
+    application/octet-stream dmg;
+    application/octet-stream eot;
+    application/octet-stream iso img;
+    application/octet-stream msi msp msm;
+    application/json json;
+    audio/midi mid midi kar;
+    audio/mpeg mp3;
+    audio/ogg ogg;
+    audio/x-m4a m4a;
+    audio/x-realaudio ra;
+    video/3gpp 3gpp 3gp;
+    video/mp4 mp4;
+    video/mpeg mpeg mpg;
+    video/quicktime mov;
+    video/webm webm;
+    video/x-flv flv;
+    video/x-m4v m4v;
+    video/x-mng mng;
+    video/x-ms-asf asx asf;
+    video/x-ms-wmv wmv;
+    video/x-msvideo avi;
+  }
+
+  access_log /dev/stdout;
+
+  # Set the default MIME type of responses; 'application/octet-stream'
+  # represents an arbitrary byte stream
+  default_type application/octet-stream;
+
+  # (Performance) When sending files, skip copying into buffer before sending.
+  sendfile on;
+  # (Only active with sendfile on) wait for packets to reach max size before
+  # sending.
+  tcp_nopush on;
+
+  # (Performance) Enable compressing responses
+  gzip on;
+  # For all clients
+  gzip_static always;
+  # Including responses to proxied requests
+  gzip_proxied any;
+  # For responses above a certain length
+  gzip_min_length 1100;
+  # That are one of the following MIME types
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  # Compress responses to a medium degree
+  gzip_comp_level 6;
+  # Using 16 buffers of 8k bytes each
+  gzip_buffers 16 8k;
+
+  # Add "Vary: Accept-Encoding” response header to compressed responses
+  gzip_vary on;
+
+  # Decompress responses if client doesn't support compressed
+  gunzip on;
+
+  # Don't compress responses if client is Internet Explorer 6
+  gzip_disable "msie6";
+
+  # Set a timeout during which a keep-alive client connection will stay open on
+  # the server side
+  keepalive_timeout 30;
+
+  # Ensure that redirects don't include the internal container PORT - <%=
+  # ENV["PORT"] %>
+  port_in_redirect off;
+
+  # (Security) Disable emitting nginx version on error pages and in the
+  # “Server” response header field
+  server_tokens off;
+
+  server {
+    listen 8080 default_server;
+    server_name _;
+
+    # Directory where static files are located
+    root /workspace/build;
+
+    location / {
+      # Specify files sent to client if specific file not requested (e.g.
+      # GET www.example.com/). NGINX sends first existing file in the list.
+      index index.html index.htm Default.htm;
+
+      try_files $uri $uri/ /index.html?$args;
+    }
+
+    # (Security) Don't serve dotfiles, except .well-known/, which is needed by
+    # LetsEncrypt
+    location ~ /\.(?!well-known) {
+      deny all;
+      return 404;
+    }
+  }
+}

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -10,7 +10,7 @@ be split across multiple cluster profiles (`build, view, and run`).
 These instructions assume that you have a TAP 1.5.x or greater `full` profile cluster up and running with the following packages installed and [kubectl](https://kubernetes.io
 docs/tasks/tools/) and the Tanzu CLI installed and configured to access your TAP cluster:
 
-* YTT
+* [ytt](https://carvel.dev/ytt/)
 * Tanzu TAP GUI
 * Tanzu Build Services
 * Tanzu Cloud Native Runtimes
@@ -96,7 +96,7 @@ This will also created the secret that will contain the AppSSO credential inform
 - **<workloadNamespace>** – Namespace where the application will be deployed
 
 ```
-ytt -f workloadRegistrationResource.yml -v workloadNamespace=<workloadNamespace>| kubectl apply –f-
+ytt -f workloadRegistrationResource.yml -v workloadNamespace=<workloadNamespace>| kubectl apply -f-
 ```
 
 For example:
@@ -138,6 +138,12 @@ For example:
 ytt -f workloads.yml -v workloadNamespace=workloads | kubectl apply -f-
 ```
 
+**NOTE** If the front end service fails to build (due to a known issue at the time of writing), you can run the following command from the root directory of the cloned
+repository updating the`<workloadNamespace>` placeholder with the namespace where the application will be deployed.
+
+```
+tanzu apps workload apply -f frontend/config/workload.yml --local-path . --sub-path frontend
+```
 
 ### Spring Cloud Gateway Deployment
 

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -176,12 +176,3 @@ For example:
 ```
 ytt -f ingress.yml -v workloadNamespace=workloads -v appDomainName=perfect300rock.com | kubectl apply -f-
 ```
-
-## Application Catalog
-
-To view the runtime resources and application live view, you will need to install the catalog-info.yaml file that contains catalog info for each component.  
-To install the catalog, navigate to the TAP GUI home page and click the `Register Entity` button.  In the URL, enter in the URL of the catalog file.  For example:
-
-```
-https://github.com/spring-cloud-services-samples/acme-fitness-store/blob/main/tanzu-application-platform/yaml/catalog-info.yaml
-```

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -1,13 +1,14 @@
 
-# Deploy to Tanzu Application Platform (TAP)   (NEED TO UPDATE FROM ACME)
+# Deploy to Tanzu Application Platform (TAP)
 
-ACME fitness store supports configuration to build and deploy to Tanzu Application Platform (TAP).  The following instructions describe an end-to-end 
-process for configuring, building, and deploying the ACME Fitness Store to a TAP `full` profile cluster.  Using additional configuration, the process can
+Animal Rescue supports configuration to build and deploy to Tanzu Application Platform (TAP).  The following instructions describe an end-to-end 
+process for configuring, building, and deploying the Animal Rescue application to a TAP `full` profile cluster.  Using additional configuration, the process can
 be split across multiple cluster profiles (`build, view, and run`).
 
 ## Prerequisites
 
-These instructions assume that you have a TAP 1.4.x or greater `full` profile clusterup and running with the following packages installed and [kubectl](https://kubernetes.io/docs/tasks/tools/) and the Tanzu CLI installed and configured to access your TAP cluster:
+These instructions assume that you have a TAP 1.5.x or greater `full` profile cluster up and running with the following packages installed and [kubectl](https://kubernetes.io
+docs/tasks/tools/) and the Tanzu CLI installed and configured to access your TAP cluster:
 
 * YTT
 * Tanzu TAP GUI
@@ -18,22 +19,22 @@ These instructions assume that you have a TAP 1.4.x or greater `full` profile cl
 * Tanzu Source Controller
 * Tanzu AppSSO
 * Certificate Manager
-* [Spring Cloud Gateway For Kubernetes](https://docs.vmware.com/en/VMware-Spring-Cloud-Gateway-for-Kubernetes/1.2/scg-k8s/GUID-index.html)
+* [Spring Cloud Gateway For Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.6/tap/spring-cloud-gateway-install-spring-cloud-gateway.html)
 
 ## Installation/Deployment Process
 
 You should first determine the full URL where you intend to deploy the application.  Optimally, you should have a domain name registered with a 
-DNS registrar and create an appropriate DNA entry for the hostname of the application.  This documentation assumes you will use the hostname `acme-fitness`.  The full URL 
+DNS registrar and create an appropriate DNS entry for the hostname of the application.  This documentation assumes you will use the hostname `animal-rescue.  The full URL 
 in this case would be:
 
 ```
-acme-fitness.<your domain name>
+animal-rescue.<your domain name>
 ```
 
 Make a note of this URL as you will need it through various steps of the following doc.
 
-It is assumed that you have cloned the Acme Fitness Store Git repository to your workstation.  All of the `ytt` commands below should be run from the
-`tap` directory in the cloned repository.
+It is assumed that you have cloned the Animal Rescue Git repository to your workstation.  All of the `ytt` commands below should be run from the
+`tanzu-application-platform` directory in the cloned repository.
 
 ### Testing Pipeline Deployment
 
@@ -43,149 +44,137 @@ to install the pipeline replacing the following placeholder:
 - **<workloadNamespace>** – Namespace where the application will be deployed
 
 ```
-kubectl apply -f testingPipeline.yaml -n <workloadNamespace>
+kubectl apply -f testingPipeline.yml -n <workloadNamespace>
 ```
 
 For example:
 
 ```
-kubectl apply -f testingPipeline.yaml -n workloads
+kubectl apply -f testingPipeline.yml -n workloads
 ```
 
 ### Let's Encrypt CA Issuer
 
-Acme Fitness Store enables TLS connections for security and reliable transport and utilizes the Let's Encrypt production CA. Install the Let's Encrypt
+Animal Rescue enables TLS connections for security and reliable transport and utilizes the Let's Encrypt production CA. Install the Let's Encrypt
 CA issuer into your cluster by running the following command and replacing the following place holder:
 
 - **<email>** – The email address of the subject responsible for the issued certificates.
  
 ```
-ytt -f caIssuer.yaml -v email=<email> | kubectl apply -f-
+ytt -f caIssuer.yml -v email=<email> | kubectl apply -f-
 ```
 
 For example:
 
 ```
-ytt -f caIssuer.yaml -v email=joe@joesgarage.com | kubectl apply -f-
+ytt -f caIssuer.yml -v email=joe@joesgarage.com | kubectl apply -f-
 ```
-
-
 
 ### AppSSO Deployment
 
-ACME requires the use of an AppSSO authorization server and client registration resource. 
+Animal Rescue requires the use of an AppSSO authorization server and client registration resource. 
 
-Deploy the authorization server instance by running the following commands and replacing these placeholders:
+Deploy the authorization server instance by running the following commands and replacing these place holders:
 
-- **<workloadNamespace>** – Namespace where the application will be deployed
+- **<serviceNamespace>** – Namespace where service instances will be deployed
 - **<devDefaultAccountUsername>** – Username for authentication
 - **<devDefaultAccountPassword>** – Password for authentication
 
 ```
-ytt -f appSSOInstance.yaml -v workloadNamespace=<workloadNamespace> -v devDefaultAccountUsername=<devDefaultAccountUsername> -v devDefaultAccountPassword=<devDefaultAccountPassword> | kubectl apply -f-
+ytt -f appSSOInstance.yml -v serviceNamespace=<serviceNamespace> -v devDefaultAccountUsername=<devDefaultAccountUsername> -v devDefaultAccountPassword=<devDefaultAccountPassword> | kubectl apply -f-
 ```
 
 For example:
 
 ```
-ytt -f appSSOInstance.yaml -v workloadNamespace=workloads -v devDefaultAccountUsername=acme -v devDefaultAccountPassword=fitness | kubectl apply -f-
+ytt -f appSSOInstance.yml -v serviceNamespace=service-instances -v devDefaultAccountUsername=animal -v devDefaultAccountPassword=rescue | kubectl apply -f-
 ```
 
-Next, create a ClientRegistration resource by running the following command and replacing these placeholders:
+Next, create a ClassClaim resource by running the following command and replacing the `<workloadNamespace>` placeholder with the namespace where the application will be deployed. 
+This will also created the secret that will contain the AppSSO credential information that will used by the Spring Cloud Gateway.
 
 - **<workloadNamespace>** – Namespace where the application will be deployed
-- **<appSSORedirectURI>** - Public URI that the authorization server will redirect to after a successful login.  This will include the full URL of your application as described earlier followed by `/login/oauth2/code/sso`
 
 ```
-ytt -f clientRegistrationResourceClaim.yaml.yaml -v workloadNamespace=<workloadNamespace> -v appSSORedirectURI=<appSSORedirectURI> | kubectl apply –f-
+ytt -f workloadRegistrationResource.yml -v workloadNamespace=<workloadNamespace>| kubectl apply –f-
 ```
 
 For example:
 
 ```
-ytt -f clientRegistrationResourceClaim.yaml -v workloadNamespace=workloads -v appSSORedirectURI=acme-fitness.perfect300rock.com/login/oauth2/code/sso | kubectl apply -f-
+ytt -f workloadRegistrationResource.yml -v workloadNamespace=workloads | kubectl apply -f-
 ```
 
-Next, obtain the appSSO issuerURI by running the following command replacing <workloadNamespace> with the name of the namespace where the application will be deployed:
+Next, obtain the appSSO issuerURI by running the following command replacing <serviceNamespace> with the name of the namespace where the service instance 
+was deployed:
 
 ```
-kubectl get authserver -n <workloadNamespace>
+kubectl get authserver -n <serviceNamespace>
 ```
 
-Save the Issuer URI as you will need it in the `workload build` section.  Also, you may need to create a new entry in your DNS registrar for this URL; this will likely be
+Save the Issuer URI as you may need to create a new entry in your DNS registrar for this URL; this will likely be
 necessary if you are NOT using wildcard records in your DNS registrar.  DNS is also required in order for the TLS certificate to be issued for the auth server.
 
-
-### Redis Deployment
-
-A Redis instance is needed for caching the Acme fitness store cart service. To deploy the Redis instance, run the command below, replacing the <workloadNamespace> placeholder 
-with the namespace where the application will be deployed and the <redisPassword> placeholder to an arbitrary password.
+Finally, obtain the appSSO credential secret name by running the following command replacing` <workloadNamespace>` placeholder with the namespace where the application will be deployed.  Save the `status.claimed-resource.name` field value as this will be the secret name that will need to provided when configuring the Spring Cloud Gateway.
 
 ```
-ytt -f redis.yaml -v workloadNamespace=<workloadNamespace> -v redisPassword=<redisPassword> | kb apply -f-
-```
-
-For example:
-
-```
-ytt -f redis.yaml -v workloadNamespace=workloads -v redisPassword=fitness | kubectl apply -f-
+tanzu service class-claim get appsso-animal-rescue -n <workloadNamespace>|
 ```
 
 ### Workload Build And Deployment
 
-To build the application services, execute the following command to apply the workload resources to your cluster while replacing these placeholders: Modify the `<workloadNamespace>` placeholder with the namespace where the application will be deployed, and the <appSSOIssuerURI> placeholder for the URL of the AppSSO authorization server that you deployed in the `AppSSO Deployment` step; you will use the Issuer URI that you saved off in that step.
+To build the application services, execute the following command to apply the workload resources to your cluster while replacing these placeholders: Modify the
+`<workloadNamespace>` placeholder with the namespace where the application will be deployed.
 
 - **<workloadNamespace>** – Namespace where the application will be deployed
-- **<appSSOIssuerURI>** – The URL of the AppSSO authorization server that you deployed in the `AppSSO Deployment` step; you will use the Issuer URI that you saved off in that step
-- **<appDomainName>** – The application’s DNS domain (the domain name you chose at the beginning of these install steps).
-- **<sourceRepo>** – The Git repository of the Acme Fitness source.  This will likely be the same repository that you cloned at the beginning of these install steps.
-- **<sourceRepoBranch>** – The Git repository branch. 
 
 ```
-ytt -f workloads.yaml -v workloadNamespace=<workloadNamespace> -v appSSOIssuerURI=<appSSOIssuerURL> -v appDomainName=<appDomainName> -v sourceRepo=<sourceRepo> -sourceRepoBranch=<sourceRepoBranch> | kubectl apply -f-
+ytt -f workloads.yml -v workloadNamespace=<workloadNamespace> | kubectl apply -f-
 ```
 
 For example:
 
 ```
-ytt -f workloads.yaml -v workloadNamespace=workloads -v appSSOIssuerURI=https://appsso-acme-fitness.workloads.perfect300rock.com  -v appDomainName=perfect300rock.com -v sourceRepo=https://github.com/gm2552-commercial/acme-fitness-store -v sourceRepoBranch=Azure  | kubectl apply -f-
+ytt -f workloads.yml -v workloadNamespace=workloads | kubectl apply -f-
 ```
 
 
 ### Spring Cloud Gateway Deployment
 
-Spring Cloud Gateway is used a "front door" for all requestions in the Acme Fitness application.  To deploy the gateway along with applicable routes, run the following commands 
-replacing the <workloadNamespace> placeholder with the namespace where the application will be deployed.
+Spring Cloud Gateway is used a "front door" for all requests in the Animal Rescue application.  To deploy the gateway along with applicable routes, run the following commands 
+replacing the <workloadNamespace> placeholder with the namespace where the application will be deployed and the <ssoSecret> placeholder with the name of the secret
+obtained in the AppSSO installation section
 
 **NOTE** It is optimal (but not necessary) if the workload build and deployment steps above have completed successfully before deploying the gateway routes.
 
 ```
-ytt -f scgInstance.yaml -v workloadNamespace=<workloadNamespace>
+ytt -f scgInstance.yml -v workloadNamespace=<workloadNamespace> -v ssoSecret=<ssoSecret>
 
-ytt -f scgRoutes.yaml -v workloadNamespace=<workloadNamespace>
+ytt -f scgRoutes.yml -v workloadNamespace=<workloadNamespace>
 ```
 
 For example:
 
 ```
-ytt -f scgInstance.yaml -v workloadNamespace=workloads | kubectl apply -f-
+ytt -f scgInstance.yml -v workloadNamespace=workloads  -v ssoSecret=dbeb6f1a-823a-439a-9a8e-44d2bc631fe0 | kubectl apply -f-
 
-ytt -f scgRoutes.yaml -v workloadNamespace=workloads | kubectl apply -f-
+ytt -f scgRoutes.yml -v workloadNamespace=workloads | kubectl apply -f-
 ```
 
 ### Ingress Deployment
 
-The Ingress resources utilizes Contour and will route traffic to the Spring Cloud Gateway.  Run the following command to create the Istio ingress resources replacing 
-`<workloadNamespace>` and `<appDomain>` placeholders with the namespace where the application will be deployed and the application’s DNS domain (the domain name you chose at the beginning of these steps).  This will create an Ingress object that uses the full URL of the application (again, the URL you chose at the beginning of these steps).
+The Ingress resources utilizes Contour and will route traffic to the Spring Cloud Gateway.  Run the following command to create the Ingress resources replacing 
+`<workloadNamespace>` and `<appDomain>` placeholders with the namespace where the application will be deployed and the application’s DNS domain (the domain name you chose at 
+the beginning of these steps).  This will create an Ingress object that uses the full URL of the application (again, the URL you chose at the beginning of these steps).
 
 ```
-ytt -f ingress.yaml -v workloadNamespace=<workloadNamespace> -v appDomainName=<appDomain> | kubectl apply -f-
+ytt -f ingress.yml -v workloadNamespace=<workloadNamespace> -v appDomainName=<appDomain> | kubectl apply -f-
 ```
 
 For example:
 
 ```
-ytt -f ingress.yaml -v workloadNamespace=workloads -v appDomainName=perfect300rock.com | kubectl apply -f-
+ytt -f ingress.yml -v workloadNamespace=workloads -v appDomainName=perfect300rock.com | kubectl apply -f-
 ```
 
 ## Application Catalog

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -118,7 +118,7 @@ necessary if you are NOT using wildcard records in your DNS registrar.  DNS is a
 Finally, obtain the appSSO credential secret name by running the following command replacing` <workloadNamespace>` placeholder with the namespace where the application will be deployed.  Save the `status.claimed-resource.name` field value as this will be the secret name that will need to provided when configuring the Spring Cloud Gateway.
 
 ```
-tanzu service class-claim get appsso-animal-rescue -n <workloadNamespace>|
+tanzu service class-claim get appsso-animal-rescue -n <workloadNamespace>
 ```
 
 ### Workload Build And Deployment

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -142,7 +142,7 @@ ytt -f workloads.yml -v workloadNamespace=workloads | kubectl apply -f-
 repository updating the`<workloadNamespace>` placeholder with the namespace where the application will be deployed.
 
 ```
-tanzu apps workload apply -f frontend/config/workload.yml --local-path . --sub-path frontend
+tanzu apps workload apply -f frontend/config/workload.yml --local-path . --sub-path frontend --namespace <workloadNamespace>
 ```
 
 ### Spring Cloud Gateway Deployment

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -1,0 +1,198 @@
+
+# Deploy to Tanzu Application Platform (TAP)   (NEED TO UPDATE FROM ACME)
+
+ACME fitness store supports configuration to build and deploy to Tanzu Application Platform (TAP).  The following instructions describe an end-to-end 
+process for configuring, building, and deploying the ACME Fitness Store to a TAP `full` profile cluster.  Using additional configuration, the process can
+be split across multiple cluster profiles (`build, view, and run`).
+
+## Prerequisites
+
+These instructions assume that you have a TAP 1.4.x or greater `full` profile clusterup and running with the following packages installed and [kubectl](https://kubernetes.io/docs/tasks/tools/) and the Tanzu CLI installed and configured to access your TAP cluster:
+
+* YTT
+* Tanzu TAP GUI
+* Tanzu Build Services
+* Tanzu Cloud Native Runtimes
+* Tanzu Out of the Box Supply Chains
+* Tanzu Out of the Box Templates
+* Tanzu Source Controller
+* Tanzu AppSSO
+* Certificate Manager
+* [Spring Cloud Gateway For Kubernetes](https://docs.vmware.com/en/VMware-Spring-Cloud-Gateway-for-Kubernetes/1.2/scg-k8s/GUID-index.html)
+
+## Installation/Deployment Process
+
+You should first determine the full URL where you intend to deploy the application.  Optimally, you should have a domain name registered with a 
+DNS registrar and create an appropriate DNA entry for the hostname of the application.  This documentation assumes you will use the hostname `acme-fitness`.  The full URL 
+in this case would be:
+
+```
+acme-fitness.<your domain name>
+```
+
+Make a note of this URL as you will need it through various steps of the following doc.
+
+It is assumed that you have cloned the Acme Fitness Store Git repository to your workstation.  All of the `ytt` commands below should be run from the
+`tap` directory in the cloned repository.
+
+### Testing Pipeline Deployment
+
+If you have a supply chain configured that includes testing, you will need to install the testing pipeline used when a build is performed.  Run the following command 
+to install the pipeline replacing the following placeholder:
+
+- **<workloadNamespace>** – Namespace where the application will be deployed
+
+```
+kubectl apply -f testingPipeline.yaml -n <workloadNamespace>
+```
+
+For example:
+
+```
+kubectl apply -f testingPipeline.yaml -n workloads
+```
+
+### Let's Encrypt CA Issuer
+
+Acme Fitness Store enables TLS connections for security and reliable transport and utilizes the Let's Encrypt production CA. Install the Let's Encrypt
+CA issuer into your cluster by running the following command and replacing the following place holder:
+
+- **<email>** – The email address of the subject responsible for the issued certificates.
+ 
+```
+ytt -f caIssuer.yaml -v email=<email> | kubectl apply -f-
+```
+
+For example:
+
+```
+ytt -f caIssuer.yaml -v email=joe@joesgarage.com | kubectl apply -f-
+```
+
+
+
+### AppSSO Deployment
+
+ACME requires the use of an AppSSO authorization server and client registration resource. 
+
+Deploy the authorization server instance by running the following commands and replacing these placeholders:
+
+- **<workloadNamespace>** – Namespace where the application will be deployed
+- **<devDefaultAccountUsername>** – Username for authentication
+- **<devDefaultAccountPassword>** – Password for authentication
+
+```
+ytt -f appSSOInstance.yaml -v workloadNamespace=<workloadNamespace> -v devDefaultAccountUsername=<devDefaultAccountUsername> -v devDefaultAccountPassword=<devDefaultAccountPassword> | kubectl apply -f-
+```
+
+For example:
+
+```
+ytt -f appSSOInstance.yaml -v workloadNamespace=workloads -v devDefaultAccountUsername=acme -v devDefaultAccountPassword=fitness | kubectl apply -f-
+```
+
+Next, create a ClientRegistration resource by running the following command and replacing these placeholders:
+
+- **<workloadNamespace>** – Namespace where the application will be deployed
+- **<appSSORedirectURI>** - Public URI that the authorization server will redirect to after a successful login.  This will include the full URL of your application as described earlier followed by `/login/oauth2/code/sso`
+
+```
+ytt -f clientRegistrationResourceClaim.yaml.yaml -v workloadNamespace=<workloadNamespace> -v appSSORedirectURI=<appSSORedirectURI> | kubectl apply –f-
+```
+
+For example:
+
+```
+ytt -f clientRegistrationResourceClaim.yaml -v workloadNamespace=workloads -v appSSORedirectURI=acme-fitness.perfect300rock.com/login/oauth2/code/sso | kubectl apply -f-
+```
+
+Next, obtain the appSSO issuerURI by running the following command replacing <workloadNamespace> with the name of the namespace where the application will be deployed:
+
+```
+kubectl get authserver -n <workloadNamespace>
+```
+
+Save the Issuer URI as you will need it in the `workload build` section.  Also, you may need to create a new entry in your DNS registrar for this URL; this will likely be
+necessary if you are NOT using wildcard records in your DNS registrar.  DNS is also required in order for the TLS certificate to be issued for the auth server.
+
+
+### Redis Deployment
+
+A Redis instance is needed for caching the Acme fitness store cart service. To deploy the Redis instance, run the command below, replacing the <workloadNamespace> placeholder 
+with the namespace where the application will be deployed and the <redisPassword> placeholder to an arbitrary password.
+
+```
+ytt -f redis.yaml -v workloadNamespace=<workloadNamespace> -v redisPassword=<redisPassword> | kb apply -f-
+```
+
+For example:
+
+```
+ytt -f redis.yaml -v workloadNamespace=workloads -v redisPassword=fitness | kubectl apply -f-
+```
+
+### Workload Build And Deployment
+
+To build the application services, execute the following command to apply the workload resources to your cluster while replacing these placeholders: Modify the `<workloadNamespace>` placeholder with the namespace where the application will be deployed, and the <appSSOIssuerURI> placeholder for the URL of the AppSSO authorization server that you deployed in the `AppSSO Deployment` step; you will use the Issuer URI that you saved off in that step.
+
+- **<workloadNamespace>** – Namespace where the application will be deployed
+- **<appSSOIssuerURI>** – The URL of the AppSSO authorization server that you deployed in the `AppSSO Deployment` step; you will use the Issuer URI that you saved off in that step
+- **<appDomainName>** – The application’s DNS domain (the domain name you chose at the beginning of these install steps).
+- **<sourceRepo>** – The Git repository of the Acme Fitness source.  This will likely be the same repository that you cloned at the beginning of these install steps.
+- **<sourceRepoBranch>** – The Git repository branch. 
+
+```
+ytt -f workloads.yaml -v workloadNamespace=<workloadNamespace> -v appSSOIssuerURI=<appSSOIssuerURL> -v appDomainName=<appDomainName> -v sourceRepo=<sourceRepo> -sourceRepoBranch=<sourceRepoBranch> | kubectl apply -f-
+```
+
+For example:
+
+```
+ytt -f workloads.yaml -v workloadNamespace=workloads -v appSSOIssuerURI=https://appsso-acme-fitness.workloads.perfect300rock.com  -v appDomainName=perfect300rock.com -v sourceRepo=https://github.com/gm2552-commercial/acme-fitness-store -v sourceRepoBranch=Azure  | kubectl apply -f-
+```
+
+
+### Spring Cloud Gateway Deployment
+
+Spring Cloud Gateway is used a "front door" for all requestions in the Acme Fitness application.  To deploy the gateway along with applicable routes, run the following commands 
+replacing the <workloadNamespace> placeholder with the namespace where the application will be deployed.
+
+**NOTE** It is optimal (but not necessary) if the workload build and deployment steps above have completed successfully before deploying the gateway routes.
+
+```
+ytt -f scgInstance.yaml -v workloadNamespace=<workloadNamespace>
+
+ytt -f scgRoutes.yaml -v workloadNamespace=<workloadNamespace>
+```
+
+For example:
+
+```
+ytt -f scgInstance.yaml -v workloadNamespace=workloads | kubectl apply -f-
+
+ytt -f scgRoutes.yaml -v workloadNamespace=workloads | kubectl apply -f-
+```
+
+### Ingress Deployment
+
+The Ingress resources utilizes Contour and will route traffic to the Spring Cloud Gateway.  Run the following command to create the Istio ingress resources replacing 
+`<workloadNamespace>` and `<appDomain>` placeholders with the namespace where the application will be deployed and the application’s DNS domain (the domain name you chose at the beginning of these steps).  This will create an Ingress object that uses the full URL of the application (again, the URL you chose at the beginning of these steps).
+
+```
+ytt -f ingress.yaml -v workloadNamespace=<workloadNamespace> -v appDomainName=<appDomain> | kubectl apply -f-
+```
+
+For example:
+
+```
+ytt -f ingress.yaml -v workloadNamespace=workloads -v appDomainName=perfect300rock.com | kubectl apply -f-
+```
+
+## Application Catalog
+
+To view the runtime resources and application live view, you will need to install the catalog-info.yaml file that contains catalog info for each component.  
+To install the catalog, navigate to the TAP GUI home page and click the `Register Entity` button.  In the URL, enter in the URL of the catalog file.  For example:
+
+```
+https://github.com/spring-cloud-services-samples/acme-fitness-store/blob/main/tanzu-application-platform/yaml/catalog-info.yaml
+```

--- a/tanzu-application-platform/README.md
+++ b/tanzu-application-platform/README.md
@@ -147,7 +147,7 @@ tanzu apps workload apply -f frontend/config/workload.yml --local-path . --sub-p
 
 ### Spring Cloud Gateway Deployment
 
-Spring Cloud Gateway is used a "front door" for all requests in the Animal Rescue application.  To deploy the gateway along with applicable routes, run the following commands 
+Spring Cloud Gateway is used as a "front door" for all requests in the Animal Rescue application.  To deploy the gateway along with applicable routes, run the following commands 
 replacing the <workloadNamespace> placeholder with the namespace where the application will be deployed and the <ssoSecret> placeholder with the name of the secret
 obtained in the AppSSO installation section
 

--- a/tanzu-application-platform/yaml/appSSOInstance.yml
+++ b/tanzu-application-platform/yaml/appSSOInstance.yml
@@ -1,0 +1,65 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:regexp", "regexp")
+    
+#@ def buildIdentityProviders():
+    - name: dev-users
+      internalUnsafe:
+        users:
+          - username: #@ data.values.devDefaultAccountUsername
+            password: #@ data.values.devDefaultAccountPassword
+            roles:
+              - "rescuer"         
+#@ end
+
+---
+apiVersion: sso.apps.tanzu.vmware.com/v1alpha1
+kind: AuthServer
+metadata:
+  name: appsso-animal-rescue
+  namespace: #@ data.values.serviceNamespace
+  labels:
+    name: appsso-animal-rescue
+    app: animal-rescue   
+  annotations:
+    sso.apps.tanzu.vmware.com/allow-client-namespaces: "*"
+    sso.apps.tanzu.vmware.com/allow-unsafe-identity-provider: ""
+    sso.apps.tanzu.vmware.com/allow-unsafe-issuer-uri: ""
+spec:
+  tls:
+    issuerRef:
+      name: letsencrypt-rescue-prod
+      kind: ClusterIssuer
+  tokenSignature:
+    signAndVerifyKeyRef:
+      name: 'appsso-animal-rescue-signing-key'
+  identityProviders: #@ buildIdentityProviders()
+---
+apiVersion: secretgen.k14s.io/v1alpha1
+kind: RSAKey
+metadata:
+  name: appsso-animal-rescue-signing-key
+  namespace: #@ data.values.serviceNamespace
+spec:
+  secretTemplate:
+    type: Opaque
+    stringData:
+      key.pem: $(privateKey)      
+      pub.pem: $(publicKey)
+      
+---
+apiVersion: sso.apps.tanzu.vmware.com/v1alpha1
+kind: ClusterWorkloadRegistrationClass
+metadata:
+  name: workloadreg-animal-rescue
+spec:
+  description:
+    short: "Animal Resuce AppSSO Workload Registrations" 
+  base: 
+    metadata:  
+      annotations:
+        sso.apps.tanzu.vmware.com/template-unsafe-redirect-uris: ""
+    spec:
+      authServerSelector:
+        matchLabels:
+          name: appsso-animal-rescue

--- a/tanzu-application-platform/yaml/caIssuer.yml
+++ b/tanzu-application-platform/yaml/caIssuer.yml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-rescue-prod
+  namespace: cert-manager
+spec:
+  acme:
+    email: #@ data.values.email
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:         
+        ingress:           
+          class: contour 

--- a/tanzu-application-platform/yaml/ingress.yml
+++ b/tanzu-application-platform/yaml/ingress.yml
@@ -1,0 +1,30 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: animal-rescue-ingress
+  namespace: #@ data.values.workloadNamespace
+spec:
+  virtualhost:
+    fqdn: #@ 'animal-rescue.' + data.values.appDomainName
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: animal-rescue-gateway
+          port: 80
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: animal-rescue-cert
+  namespace: #@ data.values.workloadNamespace
+spec:
+  commonName: #@ 'animal-rescue.' + data.values.appDomainName
+  dnsNames:
+    -  #@ 'animal-rescue.' + data.values.appDomainName
+  issuerRef:
+    name: letsencrypt-rescue-prod
+    kind: ClusterIssuer
+  secretName: animal-rescue-cert

--- a/tanzu-application-platform/yaml/ingress.yml
+++ b/tanzu-application-platform/yaml/ingress.yml
@@ -8,6 +8,8 @@ metadata:
 spec:
   virtualhost:
     fqdn: #@ 'animal-rescue.' + data.values.appDomainName
+    tls:
+      secretName: animal-rescue-cert 
   routes:
     - conditions:
         - prefix: /

--- a/tanzu-application-platform/yaml/scgInstance.yml
+++ b/tanzu-application-platform/yaml/scgInstance.yml
@@ -1,0 +1,21 @@
+#@ load("@ytt:data", "data")
+
+
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGateway
+metadata:
+  name: animal-rescue-gateway
+  namespace: #@ data.values.workloadNamespace
+spec:
+  service:
+    type: ClusterIP
+  api:
+    title: Animal Rescue API Gateway
+    description: The entrypoint for all things ACME Fitness
+    version: 1.0.0
+  env:
+    - name: spring.cloud.gateway.httpclient.connect-timeout
+      value: "90"
+  sso:
+    secret: #@ data.values.ssoSecret

--- a/tanzu-application-platform/yaml/scgInstance.yml
+++ b/tanzu-application-platform/yaml/scgInstance.yml
@@ -12,7 +12,7 @@ spec:
     type: ClusterIP
   api:
     title: Animal Rescue API Gateway
-    description: The entrypoint for all things Animal Resuce
+    description: The entrypoint for all things Animal Rescue
     version: 1.0.0
   env:
     - name: spring.cloud.gateway.httpclient.connect-timeout

--- a/tanzu-application-platform/yaml/scgInstance.yml
+++ b/tanzu-application-platform/yaml/scgInstance.yml
@@ -12,7 +12,7 @@ spec:
     type: ClusterIP
   api:
     title: Animal Rescue API Gateway
-    description: The entrypoint for all things ACME Fitness
+    description: The entrypoint for all things Animal Resuce
     version: 1.0.0
   env:
     - name: spring.cloud.gateway.httpclient.connect-timeout

--- a/tanzu-application-platform/yaml/scgRoutes.yml
+++ b/tanzu-application-platform/yaml/scgRoutes.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: #@ data.values.workloadNamespace  
 spec:
   service:
-    name: #@ 'animal-rescue-backend.' + data.values.workloadNamespace
+    name: animal-rescue-backend
     ssoEnabled: true
     filters:
       - RateLimit=10,2s

--- a/tanzu-application-platform/yaml/scgRoutes.yml
+++ b/tanzu-application-platform/yaml/scgRoutes.yml
@@ -1,0 +1,157 @@
+#@ load("@ytt:data", "data")
+
+
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayRouteConfig
+metadata:
+  name: animal-rescue-backend-route-config
+  namespace: #@ data.values.workloadNamespace  
+spec:
+  service:
+    name: #@ 'animal-rescue-backend.' + data.values.workloadNamespace
+    ssoEnabled: true
+    filters:
+      - RateLimit=10,2s
+  routes:
+    - predicates:
+        - Path=/api/animals
+        - Method=GET
+      tags:
+        - "pet adoption"
+      ssoEnabled: false
+      title: "Retrieve pets for adoption."
+      description: "Retrieve all of the animals who are up for pet adoption."
+    - predicates:
+        - Path=/api/animals/{animalId}/adoption-requests
+        - Method=POST
+      tokenRelay: true
+      tags:
+        - "pet adoption"
+      title: "Pet adoption API"
+      description: "Create pet adoption requests."
+      model:
+        responses:
+          '201':
+            description: "Adoption request created successfully."
+        requestBody:
+          description: Manage adoption requests
+          content:
+            'application/json':
+              schema:
+                type: object
+                description: Adoption request schema
+                properties:
+                  adopterName:
+                    type: string
+                  email:
+                    type: string
+                    format: email
+                  notes:
+                    type: string
+                required: [ "adopterName", "email" ]
+    - predicates:
+        - Path=/api/animals/{animalId}/adoption-requests/{adoptionId}
+        - Method=PUT,DELETE
+      tokenRelay: true
+      tags:
+        - "pet adoption"
+      title: "Pet adoption API"
+      description: "Update/delete pet adoption requests."
+      model:
+        requestBody:
+          description: Manage adoption requests
+          content:
+            'application/json':
+              schema:
+                type: object
+                description: Adoption request schema
+                properties:
+                  adopterName:
+                    type: string
+                  email:
+                    type: string
+                    format: email
+                  notes:
+                    type: string
+                required: [ "adopterName", "email" ]
+    - predicates:
+        - Path=/api/actuator/**
+      tags:
+        - actuator
+      ssoEnabled: false
+      title: "API Actuator endpoints"
+      description: "Access API actuator endpoints to provide current status of backend service."
+    - predicates:
+        - Path=/api/whoami
+        - Method=GET
+      tokenRelay: true
+      tags:
+        - sso
+      title: "Retrieve user information"
+      description: "Retrieve the current authenticated user's information."
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayMapping
+metadata:
+  name: animal-rescue-backend-route-mapping
+  namespace: #@ data.values.workloadNamespace
+spec:
+  gatewayRef:
+    name: animal-rescue-gateway
+  routeConfigRef:
+    name: animal-rescue-backend-route-config
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayRouteConfig
+metadata:
+  name: animal-rescue-frontend-route-config
+  namespace: #@ data.values.workloadNamespace  
+spec:
+  service:
+    name: animal-rescue-frontend
+    ssoEnabled: false
+  openapi:
+    generation:
+      enabled: false
+  routes:
+    - ssoEnabled: true
+      predicates:
+        - Path=/rescue/login
+        - Method=GET
+      filters:
+        - RedirectTo=302, /rescue
+      order: 0
+      tags:
+        - sso
+      title: "Animal Rescue login link"
+      description: "SSO enabled path used by the login button"
+    - predicates:
+        - Path=/
+        - Method=GET
+      filters:
+        - RedirectTo=302, /rescue
+      tags:
+        - ui
+      title: "Animal Rescue home page"
+      description: "Animal Rescue home page that doesn't require SSO login"
+    - predicates:
+        - Path=/rescue/**
+        - Method=GET
+      order: 1000
+      tags:
+        - ui
+      title: "Animal Rescue UI Pages"
+      description: "Animal Rescue UI pages that don't require SSO login"
+---
+apiVersion: "tanzu.vmware.com/v1"
+kind: SpringCloudGatewayMapping
+metadata:
+  name: animal-rescue-frontend-route-mapping
+  namespace: #@ data.values.workloadNamespace
+spec:
+  gatewayRef:
+    name: animal-rescue-gateway
+  routeConfigRef:
+    name: animal-rescue-frontend-route-config
+    

--- a/tanzu-application-platform/yaml/testingPipeline.yml
+++ b/tanzu-application-platform/yaml/testingPipeline.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rescue-noop-testing-pipeline
+  labels:
+    apps.tanzu.vmware.com/pipeline: rescue-generic-test      
+spec:
+  params:
+    - name: source-url    
+    - name: source-revision  
+  tasks:
+    - name: test
+      params:
+        - name: source-url
+          value: $(params.source-url)
+        - name: source-revision
+          value: $(params.source-revision)
+      taskSpec:
+        params:
+          - name: source-url
+          - name: source-revision
+        steps:
+          - name: test
+            image: gradle
+            script: |-
+              echo 'Empty Test Run Completed'
+---     
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rescue-java-subpath-pipeline
+  labels:
+    apps.tanzu.vmware.com/pipeline: rescue-java-subpath-test      
+spec:
+  params:
+    - name: source-url    
+    - name: source-revision  
+    - name: subpath     
+  tasks:
+    - name: test
+      params:
+        - name: source-url
+          value: $(params.source-url)
+        - name: source-revision
+          value: $(params.source-revision)
+        - name: subpath
+          value: $(params.subpath)         
+      taskSpec:
+        sidecars:
+          - image: docker:20.10-dind
+            name: docker
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /var/lib/docker
+                name: dind-storage
+              - mountPath: /var/run/
+                name: dind-socket
+        volumes:
+          - name: dind-storage
+            emptyDir: { }
+          - name: dind-socket
+            emptyDir: { }      
+        params:
+          - name: source-url
+          - name: source-revision
+          - name: subpath
+        steps:
+          - name: test
+            image: gradle
+            volumeMounts:
+              - mountPath: /var/run/
+                name: dind-socket            
+            script: |-
+              cd `mktemp -d`
+              wget -qO- $(params.source-url) | tar xvz -m
+              cd $(params.subpath)
+              if test -f gradlew; then
+                chmod a+x ./gradlew
+                ./gradlew test --info --scan
+              else
+                chmod a+x ./mvnw
+                ./mvnw test
+              fi
+         

--- a/tanzu-application-platform/yaml/workloadRegistrationResource.yml
+++ b/tanzu-application-platform/yaml/workloadRegistrationResource.yml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: services.apps.tanzu.vmware.com/v1alpha1
+kind: ClassClaim
+metadata:
+  name: appsso-animal-rescue
+  namespace: #@ data.values.workloadNamespace
+spec:
+  classRef:
+    name: workloadreg-animal-rescue
+  parameters: 
+    redirectPaths: ['/login/oauth2/code/sso']
+    workloadRef:
+      name: animal-rescue

--- a/tanzu-application-platform/yaml/workloads.yml
+++ b/tanzu-application-platform/yaml/workloads.yml
@@ -1,0 +1,79 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: animal-rescue-frontend
+  namespace: #@ data.values.workloadNamespace
+  labels:
+    apps.tanzu.vmware.com/workload-type: web
+    app.kubernetes.io/part-of: animal-rescue-frontend
+    apps.tanzu.vmware.com/has-tests: "true"
+    networking.knative.dev/visibility: cluster-local
+    apps.tanzu.vmware.com/auto-configure-actuators: "true"    
+spec:
+  build:
+    env:
+    - name: BP_EXCLUDE_FILES
+      value: build.gradle
+    - name: BP_NODE_RUN_SCRIPTS
+      value: build
+    - name: BP_WEB_SERVER_ROOT
+      value: dist      
+  params:
+  - name: annotations
+    value:
+      autoscaling.knative.dev/minScale: "1"
+      autoscaling.knative.dev/target: "200"
+      autoscaling.knative.dev/maxScale: "4"  
+  - name: ports
+    value:
+    - port: 80
+      containerPort: 8080
+      name: http
+  resources:
+    requests:
+      memory: 500M
+    limits:
+      memory: 750M    
+  source:
+    subPath: frontend
+    git:
+      url: https://github.com/spring-cloud-services-samples/animal-rescue
+      ref:
+        branch: main
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: animal-rescue-backend
+  namespace: #@ data.values.workloadNamespace
+  labels:
+    apps.tanzu.vmware.com/workload-type: web
+    app.kubernetes.io/part-of: animal-rescue-backend
+    apps.tanzu.vmware.com/has-tests: "true"
+    networking.knative.dev/visibility: cluster-local
+    apps.tanzu.vmware.com/auto-configure-actuators: "true"    
+spec:
+  build:
+    env:
+    - name: BP_JVM_VERSION
+      value: "17"
+  params:
+  - name: annotations
+    value:
+      autoscaling.knative.dev/minScale: "1"
+      autoscaling.knative.dev/target: "200"
+      autoscaling.knative.dev/maxScale: "4"  
+  resources:
+    requests:
+      memory: 500M
+    limits:
+      memory: 750M    
+  source:
+    subPath: backend
+    git:
+      url: https://github.com/spring-cloud-services-samples/animal-rescue
+      ref:
+        branch: main

--- a/tanzu-application-platform/yaml/workloads.yml
+++ b/tanzu-application-platform/yaml/workloads.yml
@@ -21,6 +21,9 @@ spec:
     - name: BP_WEB_SERVER_ROOT
       value: dist      
   params:
+  - name: testing_pipeline_matching_labels
+    value:
+        apps.tanzu.vmware.com/pipeline: rescue-generic-test    
   - name: ports
     value:
     - port: 80
@@ -56,8 +59,6 @@ spec:
   env:
     - name: MANAGEMENT_ENDPOINT_HEALTH_GROUP_LIVE_ADDITIONAL_PATH
       value: server:/startupz
-    - name: BP_SPRING_CLOUD_BINDINGS_VERSION
-      value: 1.13.0
     - name: spring_profiles_active
       value: k8s,tap
   serviceClaims:
@@ -67,6 +68,9 @@ spec:
         kind: ClassClaim
         name: appsso-animal-rescue
   params:
+  - name: testing_pipeline_matching_labels
+    value:
+        apps.tanzu.vmware.com/pipeline: rescue-generic-test 
   - name: ports
     value:
     - port: 80


### PR DESCRIPTION
Contains configuration and documentation in the tanzu-application-platform directory to build and deploy on Tanzu Application Platform.

Added the spring-cloud-bindings library in the backend project for use on Tanzu Application Platform.  This is a passive addition when running on other platform.